### PR TITLE
Implemented Predicate Push down and improved documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,80 +1,126 @@
-# Hive-BigQuery StorageHandler
-
+# Hive-BigQuery StorageHandler  
+  
 This is a Hive StorageHandler plugin that enables Hive to interact with BigQuery. It allows you keep
 your existing pipelines but move to BigQuery. It utilizes the high throughput 
 [BigQuery Storage API](https://cloud.google.com/bigquery/docs/reference/storage/) to read data and
- uses the BigQuery API to write data.
- 
- The following steps are performed under Dataproc cluster in Google Cloud Platform. If you need to 
- run in your cluster, you will need setup Google Cloud SDK and Google Cloud Storage connector for 
- Hadoop.
-
-## Getting the StorageHandler
-
-1. Check it out from GitHub.
-2. Build it with the new Google [Hadoop BigQuery Connector](https://cloud.google.com/dataproc/docs/concepts/connectors/bigquery) 
-``` shell
-git clone https://github.com/GoogleCloudPlatform/hive-bigquery-storage-handler
-cd hive-bigquery-storage-handler
-mvn clean install
-```
-3. Deploy hive-bigquery-storage-handler-1.0-shaded.jar 
-
-## Using the StorageHandler to access BigQuery
-After placing the compiled Jar to a Google Cloud Storage bucket that your Hive cluster have access
-to, you can open Hive CLI and load all the necessary Jars:
-```shell
-beeline> add jar gs://<Jar location>/hive-bigquery-storage-handler-1.0-shaded.jar;
-```
-At this point you can operate Hive just like you used to do.
-
-### Creating BigQuery tables
-If you have BigQuery table already, here is how you can define Hive table that refer to it:
-```sql
-CREATE TABLE bq_test (word_count bigint, word string)
-  STORED BY
-    'com.google.cloud.hadoop.io.bigquery.hive.HiveBigQueryStorageHandler'
-  TBLPROPERTIES (
-  'bq.dataset'='<BigQuery dataset name>',
-  'bq.table'='<BigQuery table name>',
-  'mapred.bq.project.id'='<Your Project ID>',
-  'mapred.bq.temp.gcs.path'='gs://<Bucket name>/<Temporary path>',
-  'mapred.bq.gcs.bucket'='<Cloud Storage Bucket name>'
-  );
-```
-You will need to provide the following table properties:
-
-| Property | Value |
-|--------|-----|
-| bq.dataset | BigQuery dataset id (Optional if hive database name matches BQ Dataset) |
-| bq.table | BigQuery table name (Optional if hive tablenmame matches BQ Table) |
-| mapred.bq.project.id | Your project id |
-| mapred.temp.gcs.path | Temporary file location in GCS bucket |
-| mapred.bq.gcs.bucket | Temporary GCS bucket name |
-
-### Data Type Mapping
-
-| BigQuery | Hive | DESCRIPTION | 
-|--------|-----| ---------------|
-| INTEGER | BIGINT | Signed 8-byte Integer
-| FLOAT | DOUBLE | 8-byte double precision floating point number
-| DATE | DATE | FORMAT IS YYYY-[M]M-[D]D. The range of values supported for the Date type is 0001-­01-­01 to 9999-­12-­31
-| TIMESTAMP | TIMESTAMP | Represents an absolute point in time since Unix epoch with millisecod precision (on Hive) compared to Microsecond precision on Bigquery.
-| BOOLEAN | BOOLEAN | Boolean values are represented by the keywords TRUE and FALSE
-| STRING | STRING | Variable-length character data
-| BYTES | BINARY | Variable-length binary data
-| REPEATED | ARRAY | Represents repeated values
-| RECORD | STRUCT | Represents nested structures
-
-### Caveats
-1. Ensure that bigquery column names are always lowercase
-2. timestamp column in hive is interpreted to be timezoneless and stored as an offset from the UNIX epoch with milliseconds precision.
-   To display in human readable format from_unix_time udf can be used as 
-   ```sql 
-   from_unixtime(cast(cast(<timestampcolumn> as bigint)/1000 as bigint), 'yyyy-MM-dd hh:mm:ss')    
-   ```
+ uses the BigQuery API to write data.  
    
-### Issues
-1. Writing to BigQuery will fail when using Apache Tez as the execution engine. You can use ```set hive.execution.engine=mr```
-to ask Hive use MapReduce as the execution engine to workaround it.
+ The following steps are performed under Dataproc cluster in Google Cloud Platform. If you need to run in your cluster, you
+ will need setup Google Cloud SDK and Google Cloud Storage connector for Hadoop.  
+  
+## Getting the StorageHandler  
+  
+1. Check it out from GitHub.  
+2. Build it with the new Google [Hadoop BigQuery Connector](https://cloud.google.com/dataproc/docs/concepts/connectors/bigquery)   
+``` shell  
+git clone https://github.com/GoogleCloudPlatform/hive-bigquery-storage-handler  
+cd hive-bigquery-storage-handler  
+mvn clean install  
+```  
+3. Deploy hive-bigquery-storage-handler-1.0-shaded.jar   
+  
+## Using the StorageHandler to access BigQuery  
+  
+1. Enable the BigQuery Storage API. Follow [these instructions](https://cloud.google.com/bigquery/docs/reference/storage/#enabling_the_api)  and check [pricing details](https://cloud.google.com/bigquery/pricing#storage-api) 
+       
+3. Copy the compiled Jar to a Google Cloud Storage bucket that can be accessed by your hive cluster  
+  
+4. Open Hive CLI and load the jar as shown below:  
+  
+```shell  
+hive> add jar gs://<Jar location>/hive-bigquery-storage-handler-1.0-shaded.jar;  
+```  
+  
+4. Verify the jar is loaded successfully  
+  
+```shell  
+hive> list jars;  
+```  
+  
+At this point you can operate Hive just like you used to do.  
+  
+### Creating BigQuery tables  
+If you have BigQuery table already, here is how you can define Hive table that refer to it:  
+```sql  
+CREATE TABLE bq_test (word_count bigint, word string)  
+ STORED BY 
+ 'com.google.cloud.hadoop.io.bigquery.hive.HiveBigQueryStorageHandler' 
+ TBLPROPERTIES ( 
+ 'bq.dataset'='<BigQuery dataset name>', 
+ 'bq.table'='<BigQuery table name>', 
+ 'mapred.bq.project.id'='<Your Project ID>', 
+ 'mapred.bq.temp.gcs.path'='gs://<Bucket name>/<Temporary path>', 
+ 'mapred.bq.gcs.bucket'='<Cloud Storage Bucket name>' 
+ );
+```  
 
+You will need to provide the following table properties:  
+  
+| Property | Value |  
+|--------|-----|  
+| bq.dataset | BigQuery dataset id (Optional if hive database name matches BQ dataset name) |  
+| bq.table | BigQuery table name (Optional if hive table name matches BQ table name) |  
+| mapred.bq.project.id | Your project id |  
+| mapred.temp.gcs.path | Temporary file location in GCS bucket |  
+| mapred.bq.gcs.bucket | Temporary GCS bucket name |  
+  
+### Data Type Mapping  
+  
+| BigQuery | Hive | DESCRIPTION | 
+|--------|-----| ---------------|  
+| INTEGER | BIGINT | Signed 8-byte Integer  
+| FLOAT | DOUBLE | 8-byte double precision floating point number  
+| DATE | DATE | FORMAT IS YYYY-[M]M-[D]D. The range of values supported for the Date type is 0001-­01-­01 to 9999-­12-­31  
+| TIMESTAMP | TIMESTAMP | Represents an absolute point in time since Unix epoch with millisecond precision (on Hive) compared to Microsecond precision on Bigquery.  
+| BOOLEAN | BOOLEAN | Boolean values are represented by the keywords TRUE and FALSE  
+| STRING | STRING | Variable-length character data  
+| BYTES | BINARY | Variable-length binary data  
+| REPEATED | ARRAY | Represents repeated values  
+| RECORD | STRUCT | Represents nested structures  
+  
+### Filtering
+The new API allows column pruning and predicate filtering to only read the data you are interested in.
+
+#### Column Pruning
+Since BigQuery is [backed by a columnar datastore](https://cloud.google.com/blog/big-data/2016/04/inside-capacitor-bigquerys-next-generation-columnar-storage-format), it can efficiently stream data without reading all columns.
+
+#### Predicate Filtering
+The Storage API supports arbitrary pushdown of predicate filters. To enable predicate pushdown ensure <b>hive.optimize.ppd</b> is set to true. <br/>
+Filters on all primitive type columns will be pushed to storage layer improving the performance of reads. Predicate pushdown is not supported on complex types such as arrays and structs.  For example - filters like `address.city = "Sunnyvale"` will not get pushdown to Bigquery.
+  
+### Caveats  
+1. Ensure that table exists in bigquery and column names are always lowercase  
+2. timestamp column in hive is interpreted to be timezoneless and stored as an offset from the UNIX epoch with milliseconds precision.  
+   To display in human readable format from_unix_time udf can be used as   
+   ```sql   
+   from_unixtime(cast(cast(<timestampcolumn> as bigint)/1000 as bigint), 'yyyy-MM-dd hh:mm:ss')      
+   ```  
+  ### Issues  
+1. Writing to BigQuery will fail when using Apache Tez as the execution engine. As a workaround ```set hive.execution.engine=mr``` to use MapReduce as the execution engine
+2. STRUCT type is not supported unless avro schema is explicitly specified using either avro.schema.literal or avro.schema.url table properties.
+   Below table contains all supported types defining schema explicitly.  Note: If table doesn't need struct then specifying schema is optional
+   ```sql
+    CREATE TABLE dbname.alltypeswithSchema(currenttimestamp TIMESTAMP,currentdate DATE, userid BIGINT, sessionid STRING, skills Array<String>,
+      eventduration DOUBLE, eventcount BIGINT, is_latest BOOLEAN,keyset BINARY,addresses ARRAY<STRUCT<status: STRING, street: STRING,city: STRING, state: STRING,zip: BIGINT>> )
+      STORED BY 'com.google.cloud.hadoop.io.bigquery.hive.HiveBigQueryStorageHandler'
+      TBLPROPERTIES (
+       'bq.dataset'='bqdataset',
+       'bq.table'='bqtable',
+       'mapred.bq.project.id'='bqproject',
+       'mapred.bq.temp.gcs.path'='gs://bucketname/prefix',
+       'mapred.bq.gcs.bucket'='bucketname',
+       'avro.schema.literal'='{"type":"record","name":"alltypesnonnull",
+           "fields":[{"name":"currenttimestamp","type":["null",{"type":"long","logicalType":"timestamp-micros"}], "default" : null}
+                    ,{"name":"currentdate","type":{"type":"int","logicalType":"date"}, "default" : -1},{"name":"userid","type":"long","doc":"User identifier.", "default" : -1}
+                    ,{"name":"sessionid","type":["null","string"], "default" : null},{"name":"skills","type":["null", {"type":"array","items":"string"}], "default" : null}
+                    ,{"name":"eventduration","type":["null","double"], "default" : null},{"name":"eventcount","type":["null","long"], "default" : null}
+                    ,{"name":"is_latest","type":["null","boolean"], "default" : null},{"name":"keyset","type":["null","bytes"], "default" : null}
+                    ,{"name":"addresses","type":["null", {"type":"array",
+                       "items":{"type":"record","name":"__s_0",
+                       "fields":[{"name":"status","type":"string"},{"name":"street","type":"string"},{"name":"city","type":"string"},{"name":"state","type":"string"},{"name":"zip","type":"long"}]
+                       }}], "default" : null
+                     }
+                   ]
+           }'
+      );
+   ```

--- a/src/main/java/com/google/cloud/hadoop/io/bigquery/hive/HiveBigQueryConstants.java
+++ b/src/main/java/com/google/cloud/hadoop/io/bigquery/hive/HiveBigQueryConstants.java
@@ -33,7 +33,7 @@ public class HiveBigQueryConstants {
           BigQueryConfiguration.GCS_BUCKET_KEY,
           BigQueryConfiguration.TEMP_GCS_PATH_KEY);
 
-  public static final ImmutableList<String> PPD_ALLOWED_TYPES =
+  public static final ImmutableList<String> PREDICATE_PUSHDOWN_ALLOWED_TYPES =
       ImmutableList.of(
           "int", "bigint", "float", "double", "string", "boolean", "timestamp", "date");
 }

--- a/src/main/java/com/google/cloud/hadoop/io/bigquery/hive/HiveBigQueryConstants.java
+++ b/src/main/java/com/google/cloud/hadoop/io/bigquery/hive/HiveBigQueryConstants.java
@@ -21,10 +21,19 @@ public class HiveBigQueryConstants {
   public static final String UNIQUE_JOB_KEY = "mapred.bq.unique.job.id";
   public static final String DEFAULT_BIGQUERY_DATASET_KEY = "bq.dataset";
   public static final String DEFAULT_BIGQUERY_TABLE_KEY = "bq.table";
+  public static final String PREDICATE_PUSHDOWN_COLUMNS = "ppd.columns";
+  public static final String HIVE_PROJECTION_COLUMNS = "hive.io.file.readcolumn.names";
+  public static final String BIGQUERY_PROJECTION_COLUMNS = "mapred.bq.input.selected.fields";
+  public static final String BIGQUERY_FILTER_EXPRESSION = "mapred.bq.input.sql.filter";
+  public static final String DELIMITER = ",";
 
   public static final ImmutableList<String> MANDATORY_TABLE_PROPERTIES =
       ImmutableList.of(
           BigQueryConfiguration.PROJECT_ID_KEY,
           BigQueryConfiguration.GCS_BUCKET_KEY,
           BigQueryConfiguration.TEMP_GCS_PATH_KEY);
+
+  public static final ImmutableList<String> PPD_ALLOWED_TYPES =
+      ImmutableList.of(
+          "int", "bigint", "float", "double", "string", "boolean", "timestamp", "date");
 }

--- a/src/main/java/com/google/cloud/hadoop/io/bigquery/hive/HiveBigQueryMetaHook.java
+++ b/src/main/java/com/google/cloud/hadoop/io/bigquery/hive/HiveBigQueryMetaHook.java
@@ -69,7 +69,7 @@ public class HiveBigQueryMetaHook implements HiveMetaHook {
     if(columnList != null && columnList.size() > 0) {
       //Set primitive Column names as PREDICATE_PUSHDOWN_COLUMNS
      String columnNames = columnList.stream()
-                                    .filter(column -> HiveBigQueryConstants.PPD_ALLOWED_TYPES.contains(column.getType()))
+                                    .filter(column -> HiveBigQueryConstants.PREDICATE_PUSHDOWN_ALLOWED_TYPES.contains(column.getType()))
                                     .map(column -> column.getName())
                                     .collect(Collectors.joining(HiveBigQueryConstants.DELIMITER));
 

--- a/src/main/java/com/google/cloud/hadoop/io/bigquery/hive/WrappedBigQueryAvroInputFormat.java
+++ b/src/main/java/com/google/cloud/hadoop/io/bigquery/hive/WrappedBigQueryAvroInputFormat.java
@@ -13,7 +13,6 @@
  */
 package com.google.cloud.hadoop.io.bigquery.hive;
 
-
 import com.google.cloud.hadoop.io.bigquery.DirectBigQueryInputFormat;
 import com.google.cloud.hadoop.io.bigquery.DirectBigQueryInputFormat.DirectBigQueryInputSplit;
 import com.google.cloud.hadoop.io.bigquery.hive.util.ReflectedTaskAttemptContextFactory;
@@ -27,6 +26,7 @@ import java.util.List;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.io.HiveInputFormat.HiveInputSplit;
+import org.apache.hadoop.hive.ql.plan.TableScanDesc;
 import org.apache.hadoop.hive.serde2.avro.AvroGenericRecordWritable;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.Text;
@@ -46,164 +46,176 @@ import org.slf4j.LoggerFactory;
 /*
  * Class {@link WrappedBigQueryAvroInputFormat} allows DirectBigQueryInputFormat to be used in mapred API.
  */
-public class WrappedBigQueryAvroInputFormat extends FileInputFormat<NullWritable, AvroGenericRecordWritable> {
-    private static final Logger LOG = LoggerFactory.getLogger(WrappedBigQueryAvroInputFormat.class);
-    private org.apache.hadoop.mapreduce.InputFormat<NullWritable, GenericRecord> mapreduceInputFormat =
-            new DirectBigQueryInputFormat();
+public class WrappedBigQueryAvroInputFormat
+    extends FileInputFormat<NullWritable, AvroGenericRecordWritable> {
+  private static final Logger LOG = LoggerFactory.getLogger(WrappedBigQueryAvroInputFormat.class);
+  private final org.apache.hadoop.mapreduce.InputFormat<NullWritable, GenericRecord>
+      mapreduceInputFormat = new DirectBigQueryInputFormat();
+
+  /**
+   * Creates hadoop splits (i.e BigQuery streams) so that each mapper can read data from the
+   * corresponding stream
+   *
+   * @param job Represents hadoop job
+   * @param numSplits Number of splits
+   * @return InputSplit[] - Collection of FileSplits representing BigQueryMapredInputSplit
+   * @throws IOException
+   */
+  @Override
+  public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
+    // We don't really use any information in the job Context
+    List<org.apache.hadoop.mapreduce.InputSplit> mapreduceSplits;
+    try {
+      LOG.info(
+          "Column projection:{} and filter text:{} and BQ Filter text: {} ",
+          job.get(HiveBigQueryConstants.HIVE_PROJECTION_COLUMNS),
+          job.get(TableScanDesc.FILTER_TEXT_CONF_STR)
+      );
+      job.set(
+          HiveBigQueryConstants.BIGQUERY_PROJECTION_COLUMNS,
+          job.get(HiveBigQueryConstants.HIVE_PROJECTION_COLUMNS));
+      job.set(
+          HiveBigQueryConstants.BIGQUERY_FILTER_EXPRESSION,
+          job.get(TableScanDesc.FILTER_TEXT_CONF_STR, ""));
+      // job.setInt("mapred.map.tasks", numSplits);
+
+      mapreduceSplits = mapreduceInputFormat.getSplits(Job.getInstance(job));
+    } catch (InterruptedException ex) {
+      throw new IOException("Interrupted", ex);
+    }
+
+    if (mapreduceSplits == null) {
+      return null;
+    }
+
+    // Wrap DirectBigQueryInputSplit inside this FileSplit
+    FileSplit[] splits = new FileSplit[mapreduceSplits.size()];
+    Path path = new Path(job.get("location"));
+    int ii = 0;
+    for (org.apache.hadoop.mapreduce.InputSplit mapreduceSplit : mapreduceSplits) {
+      LOG.info("Split[{}] = {}", ii, mapreduceSplit);
+      splits[ii++] = new BigQueryMapredInputSplit(mapreduceSplit, path);
+    }
+    return splits;
+  }
+
+  /**
+   * Creates RecordReader<K,V> where key is null and Value is AvroGenericRecord representing BQ Row
+   *
+   * @param inputSplit InputSplit (i.e BQ Stream object) containing slice of records
+   * @param conf Job Configuration
+   * @param reporter reporter instance
+   * @return instance of BigQueryMapredAvroRecordReader
+   * @throws IOException
+   */
+  @Override
+  public RecordReader<NullWritable, AvroGenericRecordWritable> getRecordReader(
+      InputSplit inputSplit, JobConf conf, Reporter reporter) throws IOException {
+    Preconditions.checkArgument(
+        inputSplit instanceof BigQueryMapredInputSplit,
+        "Split must be an instance of BigQueryMapredInputSplit");
+
+    try {
+      // The assertion is that this taskAttemptId isn't actually used, but in Hadoop2 calling
+      // toString() on an emptyJobID results in an NPE.
+      TaskAttemptID taskAttemptId = new TaskAttemptID();
+      TaskAttemptContext context =
+          ReflectedTaskAttemptContextFactory.getContext(conf, taskAttemptId);
+      org.apache.hadoop.mapreduce.InputSplit mapreduceInputSplit =
+          ((BigQueryMapredInputSplit) inputSplit).getMapreduceInputSplit();
+      LOG.info(
+          "mapreduceInputSplit is {}, class is {}",
+          mapreduceInputSplit,
+          mapreduceInputSplit.getClass().getName());
+      org.apache.hadoop.mapreduce.RecordReader<NullWritable, GenericRecord> mapreduceRecordReader =
+          mapreduceInputFormat.createRecordReader(mapreduceInputSplit, context);
+      mapreduceRecordReader.initialize(mapreduceInputSplit, context);
+      long splitLength = inputSplit.getLength();
+
+      if (mapreduceInputSplit instanceof DirectBigQueryInputSplit) {
+        splitLength = ((DirectBigQueryInputSplit) mapreduceInputSplit).getLimit();
+      }
+
+      return new BigQueryMapredAvroRecordReader(mapreduceRecordReader, splitLength);
+    } catch (InterruptedException ex) {
+      throw new IOException("Interrupted", ex);
+    }
+  }
+
+  /**
+   * Mapreduce input split representing a Big Query Stream to be processed by each mapper.
+   * mapreduceInputSplit holds an instance of
+   * com.google.cloud.hadoop.io.bigquery.DirectBigQueryInputFormat$DirectBigQueryInputSplit
+   */
+  static class BigQueryMapredInputSplit extends HiveInputSplit {
+    private final org.apache.hadoop.mapreduce.InputSplit mapreduceInputSplit;
+    private final Writable writableInputSplit;
+    private Path path;
+
+    @VisibleForTesting
+    BigQueryMapredInputSplit() {
+      // Used by Hadoop serialization via reflection.
+      this(new DirectBigQueryInputSplit("dummy", "", 0), null);
+    }
 
     /**
-     * Creates hadoop splits (i.e BigQuery streams) so that each mapper can read data from the corresponding stream
-     * @param job  Represents hadoop job
-     * @param numSplits Number of splits
-     * @return InputSplit[] - Collection of FileSplits representing BigQueryMapredInputSplit
-     * @throws IOException
+     * @param mapreduceInputSplit An InputSplit that also implements Writable.
+     * @param path A HCFS path of that split. Hive assumes tables are file-based.
      */
+    BigQueryMapredInputSplit(
+        org.apache.hadoop.mapreduce.InputSplit mapreduceInputSplit, Path path) {
+      super();
+      this.mapreduceInputSplit = mapreduceInputSplit;
+      this.writableInputSplit = (Writable) mapreduceInputSplit;
+      this.path = path;
+    }
+
+    /** @param mapreduceInputSplit An InputSplit that also implements Writable. */
+    public BigQueryMapredInputSplit(org.apache.hadoop.mapreduce.InputSplit mapreduceInputSplit) {
+      Preconditions.checkArgument(
+          mapreduceInputSplit instanceof Writable, "inputSplit must also be Writable");
+      this.mapreduceInputSplit = mapreduceInputSplit;
+      this.writableInputSplit = (Writable) mapreduceInputSplit;
+    }
+
     @Override
-    public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
-        // We don't really use any information in the job Context
-        List<org.apache.hadoop.mapreduce.InputSplit> mapreduceSplits;
-        try {
-            mapreduceSplits = mapreduceInputFormat.getSplits(Job.getInstance(job));
-        } catch (InterruptedException ex) {
-            throw new IOException("Interrupted", ex);
-        }
-
-        if (mapreduceSplits == null) {
-            return null;
-        }
-
-        //Wrap DirectBigQueryInputSplit inside this FileSplit
-        FileSplit[] splits = new FileSplit[mapreduceSplits.size()];
-        Path path = new Path(job.get("location"));
-        int ii = 0;
-        for (org.apache.hadoop.mapreduce.InputSplit mapreduceSplit :
-            mapreduceSplits) {
-            LOG.info("Split[{}] = {}", ii, mapreduceSplit);
-            splits[ii++] = new BigQueryMapredInputSplit(mapreduceSplit, path);
-        }
-        return splits;
+    public long getLength() {
+      return 1L;
     }
 
-    /**
-     *  Creates RecordReader<K,V> where key is null and Value is AvroGenericRecord representing BQ Row
-     *
-     * @param inputSplit InputSplit (i.e BQ Stream object) containg slice of records
-     * @param conf  Job Configuration
-     * @param reporter reporter instance
-     * @return instance of BigQueryMapredAvroRecordReader
-     * @throws IOException
-     */
     @Override
-    public RecordReader<NullWritable, AvroGenericRecordWritable> getRecordReader(
-        InputSplit inputSplit, JobConf conf, Reporter reporter) throws IOException {
-        Preconditions.checkArgument(inputSplit instanceof BigQueryMapredInputSplit,
-               "Split must be an instance of BigQueryMapredInputSplit");
-
-        try {
-            // The assertion is that this taskAttemptId isn't actually used, but in Hadoop2 calling
-            // toString() on an emptyJobID results in an NPE.
-            TaskAttemptID taskAttemptId = new TaskAttemptID();
-            TaskAttemptContext context =
-                    ReflectedTaskAttemptContextFactory.getContext(conf, taskAttemptId);
-            org.apache.hadoop.mapreduce.InputSplit mapreduceInputSplit =
-                    ((BigQueryMapredInputSplit) inputSplit).getMapreduceInputSplit();
-            LOG.info("mapreduceInputSplit is {}, class is {}",
-                    mapreduceInputSplit, mapreduceInputSplit.getClass().getName());
-            org.apache.hadoop.mapreduce.RecordReader<NullWritable, GenericRecord>  mapreduceRecordReader =
-                   mapreduceInputFormat.createRecordReader(mapreduceInputSplit, context);
-            mapreduceRecordReader.initialize(mapreduceInputSplit, context);
-            long splitLength = inputSplit.getLength();
-
-            if(mapreduceInputSplit instanceof DirectBigQueryInputSplit ){
-                splitLength = ((DirectBigQueryInputSplit)mapreduceInputSplit).getLimit();
-            }
-
-            return new BigQueryMapredAvroRecordReader(mapreduceRecordReader, splitLength);
-        } catch (InterruptedException ex) {
-            throw new IOException("Interrupted", ex);
-        }
+    public String[] getLocations() throws IOException {
+      try {
+        return mapreduceInputSplit.getLocations();
+      } catch (InterruptedException ex) {
+        throw new IOException("Interrupted", ex);
+      }
     }
 
-    /**
-     * Mapreduce input split representing a Big Query Stream to be processed by each mapper.
-     * mapreduceInputSplit holds an instance of com.google.cloud.hadoop.io.bigquery.DirectBigQueryInputFormat$DirectBigQueryInputSplit
-     */
-    static class BigQueryMapredInputSplit extends HiveInputSplit {
-        private org.apache.hadoop.mapreduce.InputSplit mapreduceInputSplit;
-        private Writable writableInputSplit;
-        private Path path;
-
-        @VisibleForTesting
-        BigQueryMapredInputSplit() {
-            // Used by Hadoop serialization via reflection.
-            this(new DirectBigQueryInputSplit("dummy","",0), null);
-        }
-
-        /**
-         * @param mapreduceInputSplit An InputSplit that also
-         *        implements Writable.
-         * @param path A HCFS path of that split. Hive assumes tables are file-based.
-         */
-        public BigQueryMapredInputSplit(
-            org.apache.hadoop.mapreduce.InputSplit mapreduceInputSplit, Path path) {
-            super();
-            this.mapreduceInputSplit = mapreduceInputSplit;
-            this.writableInputSplit = (Writable) mapreduceInputSplit;
-            this.path = path;
-        }
-
-        /**
-         * @param mapreduceInputSplit An InputSplit that also
-         *        implements Writable.
-         */
-        public BigQueryMapredInputSplit(
-            org.apache.hadoop.mapreduce.InputSplit mapreduceInputSplit) {
-            Preconditions.checkArgument(
-                mapreduceInputSplit instanceof Writable,
-                "inputSplit must also be Writable");
-            this.mapreduceInputSplit = mapreduceInputSplit;
-            writableInputSplit = (Writable) mapreduceInputSplit;
-        }
-
-        @Override
-        public long getLength() {
-            return 1L;
-        }
-
-        @Override
-        public String[] getLocations() throws IOException {
-            try {
-                return mapreduceInputSplit.getLocations();
-            } catch (InterruptedException ex) {
-                throw new IOException("Interrupted", ex);
-            }
-        }
-
-        @Override
-        public void readFields(DataInput in) throws IOException {
-            path = new Path(Text.readString(in));
-            writableInputSplit.readFields(in);
-        }
-
-        @Override
-        public void write(DataOutput out) throws IOException {
-            Text.writeString(out, path.toString());
-            writableInputSplit.write(out);
-        }
-
-        public org.apache.hadoop.mapreduce.InputSplit getMapreduceInputSplit() {
-            return mapreduceInputSplit;
-        }
-
-        @Override
-        public String toString() {
-            return mapreduceInputSplit.toString();
-        }
-
-        @Override
-        public Path getPath() {
-            return path;
-        }
+    @Override
+    public void readFields(DataInput in) throws IOException {
+      path = new Path(Text.readString(in));
+      writableInputSplit.readFields(in);
     }
 
+    @Override
+    public void write(DataOutput out) throws IOException {
+      Text.writeString(out, path.toString());
+      writableInputSplit.write(out);
+    }
+
+    public org.apache.hadoop.mapreduce.InputSplit getMapreduceInputSplit() {
+      return mapreduceInputSplit;
+    }
+
+    @Override
+    public String toString() {
+      return mapreduceInputSplit.toString();
+    }
+
+    @Override
+    public Path getPath() {
+      return path;
+    }
+  }
 }

--- a/src/main/java/com/google/cloud/hadoop/io/bigquery/hive/WrappedBigQueryAvroInputFormat.java
+++ b/src/main/java/com/google/cloud/hadoop/io/bigquery/hive/WrappedBigQueryAvroInputFormat.java
@@ -77,7 +77,6 @@ public class WrappedBigQueryAvroInputFormat
       job.set(
           HiveBigQueryConstants.BIGQUERY_FILTER_EXPRESSION,
           job.get(TableScanDesc.FILTER_TEXT_CONF_STR, ""));
-      // job.setInt("mapred.map.tasks", numSplits);
 
       mapreduceSplits = mapreduceInputFormat.getSplits(Job.getInstance(job));
     } catch (InterruptedException ex) {

--- a/src/test/java/com/google/cloud/hadoop/io/bigquery/hive/HiveBigQueryMetaHookTest.java
+++ b/src/test/java/com/google/cloud/hadoop/io/bigquery/hive/HiveBigQueryMetaHookTest.java
@@ -7,9 +7,8 @@ import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.junit.*;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 
@@ -45,7 +44,11 @@ public class HiveBigQueryMetaHookTest {
         this.hiveTable.setParameters(this.tableParameters);
 
         this.hiveTable.setSd(new StorageDescriptor());
-
+        List<FieldSchema> columns = new ArrayList<>();
+        columns.add(new FieldSchema("id", "bigint", "Id column"));
+        columns.add(new FieldSchema("name", "string", "Id column"));
+        columns.add(new FieldSchema("skills", "array<string>",""));
+        this.hiveTable.getSd().setCols(columns);
     }
 
     @Test(expected = MetaException.class)
@@ -88,6 +91,12 @@ public class HiveBigQueryMetaHookTest {
         hiveBigQueryMetaHook.preCreateTable(this.hiveTable);
         assertEquals(this.hiveTable.getDbName(), this.hiveTable.getParameters().get(HiveBigQueryConstants.DEFAULT_BIGQUERY_DATASET_KEY));
         assertEquals(this.hiveTable.getTableName(), this.hiveTable.getParameters().get(HiveBigQueryConstants.DEFAULT_BIGQUERY_TABLE_KEY));
+    }
+
+    @Test
+    public void testAssigningPredicatePushdownColumns() throws  MetaException {
+        hiveBigQueryMetaHook.preCreateTable(this.hiveTable);
+        assertEquals(this.hiveTable.getParameters().get(HiveBigQueryConstants.PREDICATE_PUSHDOWN_COLUMNS), "id,name");
     }
 
 }


### PR DESCRIPTION
Predicate Push down support for all primitive types has been implemented to address Issue # 9.  
Documentation was improved to provide additional details related to BQ Storage API and Struct Type Support.  

Fixes #9 