### PR TITLE
Fix compilation error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,12 @@
             <artifactId>hive-exec</artifactId>
             <version>${hive.version}</version>
             <scope>provided</scope>
+            <exclusions>
+              <exclusion>
+                <groupId>org.pentaho</groupId>
+                <artifactId>*</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The pentaho package apparently isn't hosted on Maven any more